### PR TITLE
Upgrade Clock library to 5.0 leveraging mostly Symfony

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": "^8.4",
         "ext-mongodb": "*",
         "mongodb/mongodb": "^2.1",
-        "recruiterphp/clock": "^4.1"
+        "recruiterphp/clock": "^5.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.47",

--- a/src/Recruiter/Concurrency/PeriodicalCheck.php
+++ b/src/Recruiter/Concurrency/PeriodicalCheck.php
@@ -4,24 +4,20 @@ declare(strict_types=1);
 
 namespace Recruiter\Concurrency;
 
-use Recruiter\Clock;
-use Recruiter\Clock\SystemClock;
+use Symfony\Component\Clock\ClockInterface;
+use Symfony\Component\Clock\NativeClock;
 
 class PeriodicalCheck
 {
     private array|\Closure $check;
     private int $lastCheck;
 
-    public static function every(int $seconds, ?Clock $clock = null): self
+    public static function every(int $seconds, ?ClockInterface $clock = null): self
     {
-        if (null === $clock) {
-            $clock = new SystemClock();
-        }
-
-        return new self($seconds, $clock);
+        return new self($seconds, $clock ?? new NativeClock());
     }
 
-    private function __construct(private readonly int $seconds, private readonly Clock $clock)
+    private function __construct(private readonly int $seconds, private readonly ClockInterface $clock)
     {
         $this->lastCheck = 0;
     }
@@ -43,7 +39,7 @@ class PeriodicalCheck
 
     public function execute(): void
     {
-        $now = $this->clock->current()->getTimestamp();
+        $now = $this->clock->now()->getTimestamp();
         if ($now - $this->lastCheck >= $this->seconds) {
             call_user_func($this->check);
             $this->lastCheck = $now;

--- a/tests/Recruiter/Concurrency/PeriodicalCheckTest.php
+++ b/tests/Recruiter/Concurrency/PeriodicalCheckTest.php
@@ -8,7 +8,7 @@ use Eris;
 use Eris\Generator;
 use Eris\Listener;
 use PHPUnit\Framework\TestCase;
-use Recruiter\Clock\SettableClock;
+use Symfony\Component\Clock\MockClock;
 
 class PeriodicalCheckTest extends TestCase
 {
@@ -27,8 +27,8 @@ class PeriodicalCheckTest extends TestCase
                 ),
             )
             // ->hook(Listener\collectFrequencies())
-            ->then(function ($startingDate, $period, $deltas): void {
-                $clock = new SettableClock($startingDate);
+            ->then(function (\DateTime $startingDate, int $period, array $deltas): void {
+                $clock = new MockClock(\DateTimeImmutable::createFromMutable($startingDate));
                 $check = PeriodicalCheck::every($period, $clock);
                 $this->counter = 0;
                 $check->onFire(function (): void {
@@ -36,7 +36,7 @@ class PeriodicalCheckTest extends TestCase
                 });
                 $check->__invoke();
                 foreach ($deltas as $delta) {
-                    $clock->advance($delta);
+                    $clock->sleep($delta);
                     $check->__invoke();
                 }
                 $totalInterval = array_sum($deltas);


### PR DESCRIPTION
- Switching from Recruiter Clock to Symfony Clock
- Leverage Sleep feature from Symfony's interface